### PR TITLE
Use Task-Space Reference Velocity

### DIFF
--- a/src/karmaMotor/main.cpp
+++ b/src/karmaMotor/main.cpp
@@ -612,7 +612,7 @@ protected:
     void setTaskVelocities(const Vector& xs, const Vector& xf)
     {
         double Ts=0.1;  // controller's sample time [s]
-        double T=4.0;   // how long it takes to move to the target [s]
+        double T=6.0;   // how long it takes to move to the target [s]
         double v_max=0.1;   // max cartesian velocity [m/s]
 
         // instantiate the controller
@@ -630,13 +630,15 @@ protected:
 
             // enforce velocity bounds
             for (size_t i=0; i<vel_x.length(); i++)
-                vel_x[i]=sign(vel_x[i])*std::min(v_max,fabs(vel_x[i]));
-            
+                vel_x[i]=sign(e[i])*std::min(v_max,fabs(vel_x[i]));
+
             // call the proper method
             iCartCtrl->setTaskVelocities(vel_x,Vector(4,0.0));
             Time::delay(Ts);
 
-            done=(norm(e)<0.01);
+            done=(norm(e.subVector(0,1))<0.01);
+            if (done)
+                yDebug("xf= %s; x= %s",xf.toString(3,3).c_str(),x.toString(3,3).c_str());
         }
 
         iCartCtrl->stopControl();


### PR DESCRIPTION
Hi @towardthesea,

This PR attempts to make the straight motion of push / pull actions smoother and thus less _sticky-slip_ by relying on the [**Task-Space Reference Velocity**][1] modality.

I've tested it with the simulator and it works, but given it's quite critical, I'd like you to **validate it carefully on the real robot before merging**, once you'll be back from holiday. Therefore, I've tagged the PR as [**[WIP]**][2].

[1]: http://wiki.icub.org/iCub/main/dox/html/icub_cartesian_interface.html#sec_cart_taskrefvel
[2]: https://github.com/robotology/QA/issues/121